### PR TITLE
fix: prepare hooks for NativeScript 6.0 release

### DIFF
--- a/src/scripts/android/appsync-android.js
+++ b/src/scripts/android/appsync-android.js
@@ -1,5 +1,6 @@
 const fs = require('fs'),
-    path = require('path');
+  path = require('path'),
+  prepareHooksHelper = require("../prepare-hooks-helper");
 
 // patch NativeScriptApplication.java so it calls TNSAppSync (which is included in the bundled .aar file)
 function patchNativeScriptApplication(androidProjectFolder) {
@@ -13,18 +14,18 @@ function patchNativeScriptApplication(androidProjectFolder) {
     // patch NativeScriptApplication so TNSAppSync.activatePackage it's only called once in the app lifecycle
     const tnsAppFile = path.join(nsPackage, "NativeScriptApplication.java");
     replaceInFile(
-        tnsAppFile,
-        'super.onCreate();',
-        // adding a space so we don't do this more than once
-        'super.onCreate() ;\n\t\t\t\tTNSAppSync.activatePackage(this);');
+      tnsAppFile,
+      'super.onCreate();',
+      // adding a space so we don't do this more than once
+      'super.onCreate() ;\n\t\t\t\tTNSAppSync.activatePackage(this);');
 
-  } catch(e) {
+  } catch (e) {
     console.log("AppSync Android hook error: " + e);
   }
 }
 
 function replaceInFile(someFile, what, by) {
-  fs.readFile(someFile, 'utf8', function (err,data) {
+  fs.readFile(someFile, 'utf8', function (err, data) {
     if (err) {
       return console.log(err);
     }
@@ -36,11 +37,11 @@ function replaceInFile(someFile, what, by) {
   });
 }
 
-module.exports = function (logger, platformsData, projectData, hookArgs) {
-  const androidProjectFolder = path.join(projectData.platformsDir, "android");
+module.exports = function ($injector, hookArgs) {
+  const platform = prepareHooksHelper.getPlatformFromPrepareHookArgs(hookArgs);
 
-  return new Promise(function (resolve, reject) {
+  if (platform === 'android') {
+    const androidProjectFolder = prepareHooksHelper.getNativeProjectDir($injector, platform, hookArgs);
     patchNativeScriptApplication(androidProjectFolder);
-    resolve();
-  });
+  }
 };

--- a/src/scripts/prepare-hooks-helper.js
+++ b/src/scripts/prepare-hooks-helper.js
@@ -1,0 +1,33 @@
+function getProjectData ($injector, hookArgs) {
+  if (hookArgs && hookArgs.projectData) {
+    // CLI 5.4.x or older
+    return hookArgs.projectData;
+  }
+
+  // CLI 6.0.0 and later
+  const projectDir = hookArgs && hookArgs.prepareData && hookArgs.prepareData.projectDir;
+  const $projectDataService = $injector.resolve('projectDataService')
+  const projectData = $projectDataService.getProjectData(projectDir);
+  return projectData;
+}
+
+module.exports.getPlatformFromPrepareHookArgs = function (hookArgs) {
+  const platform = (hookArgs && (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform)) || '').toLowerCase();
+  return platform;
+}
+
+module.exports.getNativeProjectDir = function ($injector, platform, hookArgs) {
+  let service = null;
+  try {
+    // CLI 6.0.0 and later
+    service = $injector.resolve('platformsDataService');
+  } catch (err) {
+    // CLI 5.4.x and below:
+    service = $injector.resolve('platformsData');
+  }
+
+  const projectData = getProjectData($injector, hookArgs);
+  const platformData = service.getPlatformData(platform, projectData);
+
+  return platformData.projectRoot;
+}


### PR DESCRIPTION
In NativeScript 6.0 release hookArgs are changed, so this requires changes in the plugin. Apply required changes and make them compatible with CLI 5.4.x (and older) and 6.x.x versions.